### PR TITLE
fix: wait timeout promise before connect on ws error

### DIFF
--- a/js/ws/index.js
+++ b/js/ws/index.js
@@ -55,7 +55,7 @@ class WS {
             this.#state = ERROR
             // some reporting or something??
             // some backoff?
-            new Promise(res => setTimeout(res, 1000))
+            await new Promise(res => setTimeout(res, 1000))
             this.#connect()
         }
 


### PR DESCRIPTION
Waiting timeout promise before reconnection to ws on error handler.